### PR TITLE
Update planning statuses

### DIFF
--- a/ai-assistant/README.md
+++ b/ai-assistant/README.md
@@ -8,12 +8,12 @@ This project uses the `ai-assistant/` folder to maintain context and institution
 
 ```
 ai-assistant/
-├── context/                 # Background information and methodologies
+├── context/                 # Background information and methodologies (TODO)
 │   ├── development-context.md      # Software development best practices
 │   └── echo-protocol-context.md    # Echo Protocol philosophy and structure
 ├── planning/                # Implementation plans and roadmaps
 │   └── echo-copilot-implementation-plan.md  # Current project plan (PRS-generated)
-└── echos/                  # Development-specific echo templates
+└── echos/                  # Development-specific echo templates (TODO)
     └── README.md           # Documentation of custom echo adaptations
 ```
 
@@ -23,7 +23,7 @@ ai-assistant/
 
 When working on this project:
 
-1. **Reference existing context** - Check `context/` files for background information
+1. **Reference existing context** - (pending) `context/` files will store background information
 2. **Update plans** - Modify files in `planning/` as the project evolves
 3. **Store analysis** - Save diagnostic results, evaluations, and other echo outputs
 4. **Maintain continuity** - Use stored context to maintain consistency across sessions

--- a/ai-assistant/planning/M1-build-system-diagnostic.md
+++ b/ai-assistant/planning/M1-build-system-diagnostic.md
@@ -2,7 +2,7 @@
 
 **Generated**: June 2, 2025  
 **Module**: M1 - Fix Build System  
-**Status**: In Progress - Demonstrating Correct Echo Usage  
+**Status**: In Progress - Build directory missing
 **Priority**: Critical (blocks M2-M6)
 
 ---

--- a/ai-assistant/planning/M2-ready-to-use-planning.md
+++ b/ai-assistant/planning/M2-ready-to-use-planning.md
@@ -2,7 +2,7 @@
 
 **Generated**: June 2, 2025  
 **Module**: M2 - Create Ready-to-Use File  
-**Status**: Pending M1  
+**Status**: In Progress - Initial instructions file present, build incomplete
 **Priority**: Critical (core deliverable)
 
 ---

--- a/ai-assistant/planning/M3-installer-evaluation.md
+++ b/ai-assistant/planning/M3-installer-evaluation.md
@@ -2,7 +2,7 @@
 
 **Generated**: June 2, 2025  
 **Module**: M3 - Advanced Installer Scripts  
-**Status**: ✅ COMPLETED  
+**Status**: In Progress - Installer scripts missing
 **Priority**: High (user experience enhancement)
 
 ---
@@ -388,7 +388,7 @@ npx https://raw.githubusercontent.com/beogip/echos-copilot/main/install.js
 
 ---
 
-## **M3 Status: COMPLETED** ✅
+## **M3 Status: In Progress** ❌
 
 **Implementation Quality**: Excellent  
 **User Experience**: Professional  

--- a/ai-assistant/planning/echo-copilot-implementation-plan.md
+++ b/ai-assistant/planning/echo-copilot-implementation-plan.md
@@ -196,12 +196,12 @@ progress_metrics:
 
 ## **Status Tracking**
 
-- [ ] **M1: Fix Build System**
-- [ ] **M2: Create Ready-to-Use**
-- [ ] **M3: Advanced Installer**
-- [ ] **M4: Testing & Validation**
-- [ ] **M5: Documentation**
-- [ ] **M6: Distribution**
+- [ ] **M1: Fix Build System** – build directory and scripts missing
+- [ ] **M2: Create Ready-to-Use** – initial instructions file present
+- [ ] **M3: Advanced Installer** – installer scripts not implemented
+- [ ] **M4: Testing & Validation** – test suite exists but depends on installers
+- [ ] **M5: Documentation** – README and installation guide drafted
+- [ ] **M6: Distribution** – not started
 
 ---
 


### PR DESCRIPTION
## Summary
- update module status lines in M1, M2 and M3 planning files
- note missing directories in ai-assistant README
- add progress notes in implementation plan

## Testing
- `npm test` *(fails: Cannot find module '/workspace/echos-copilot/build/test.js')*

------
https://chatgpt.com/codex/tasks/task_e_683f6df328548323af3f625344dcd773